### PR TITLE
Walrus vs Mustache.erl benchmark

### DIFF
--- a/benchmarks/tpl_bench.erl
+++ b/benchmarks/tpl_bench.erl
@@ -1,0 +1,51 @@
+-module(tpl_bench).
+-export([run/0]).
+%% Mustache.erl: https://github.com/mojombo/mustache.erl
+%% Walrus: https://github.com/devinus/walrus
+%% 
+%% Sample results:
+%%
+%% Mustache ---
+%%  Total time: 5.2954s
+%%  Mean render time: 0.5295ms
+%% Walrus ---
+%%  Total time: 0.0209s
+%%  Mean render time: 0.0021ms
+
+-define(COUNT, 10000).
+
+run() ->
+  Beer = dict:from_list([{name, "Beer"}, {tastiness, 5}]),
+  Juice = dict:from_list([{name, "Juice"}, {tastiness, 8}]),
+  Ctx1 = dict:from_list([{customer, "Devin & Jane"},{drinks,[Beer,Juice]}]),
+  Ctx2 = [{customer, "Devin & Jane"}, {drinks, [[{name, "Beer"}, {tastiness, 5}], [{name, "Juice"}, {tastiness, 8}]]}],
+  Template = "Hello {{{customer}}}.\n\nDrinks:\n\n{{#drinks}}\n    - {{name}}, {{tastiness}}\n{{/drinks}}",
+  CT1 = mustache:compile(Template),
+  CT2 = walrus:compile(Template),
+  T0 = erlang:now(),
+  render(CT1, Ctx1, ?COUNT),
+  T1 = erlang:now(),
+  Diff1 = timer:now_diff(T1, T0),
+  Mean1 = Diff1 / ?COUNT,
+  io:format("Mustache ---"),
+  io:format("~nTotal time: ~.4fs~n", [Diff1 / 1000000]),
+  io:format("Mean render time: ~.4fms~n", [Mean1 / 1000]),
+
+  T2 = erlang:now(),
+  render(CT2, Ctx2, ?COUNT),
+  T3 = erlang:now(),
+  Diff2 = timer:now_diff(T3, T2),
+  Mean2 = Diff2 / ?COUNT,
+
+  io:format("Walrus ---"),
+  io:format("~n Total time: ~.4fs~n", [Diff2 / 1000000]),
+  io:format(" Mean render time: ~.4fms~n", [Mean2 / 1000]).
+
+render(CT, Ctx, 1) ->
+  Out = CT(Ctx),
+  %% uncomment to show one rendering result
+  % io:format(Out,[]),
+  ok;
+render(CT, Ctx, N) ->
+  CT(Ctx),
+  render(CT, Ctx, N - 1).

--- a/benchmarks/tpl_bench.erl
+++ b/benchmarks/tpl_bench.erl
@@ -1,4 +1,6 @@
 -module(tpl_bench).
+-author("Ivan Blinkov <ivan@blinkov.ru>").
+
 -export([run/0]).
 %% Mustache.erl: https://github.com/mojombo/mustache.erl
 %% Walrus: https://github.com/devinus/walrus

--- a/src/walrus.erl
+++ b/src/walrus.erl
@@ -75,12 +75,14 @@ get(Key, Context) ->
 
 -spec stringify(Value :: stringifiable(), Context :: context(), Escape :: boolean())
     -> iolist().
+stringify(Value, _Context, false) when is_binary(Value) ->
+    binary_to_list(Value);
+stringify(Value, _Context, true) when is_binary(Value) ->
+    escape(binary_to_list(Value));
 stringify(Value, _Context, false) when is_list(Value) ->
     Value;
 stringify(Value, _Context, true) when is_list(Value) ->
     escape(Value);
-stringify(Value, _Context, true) when is_binary(Value) ->
-    escape(binary_to_list(Value));
 stringify(Value, _Context, _Escape) when is_integer(Value) ->
     integer_to_list(Value);
 stringify(Value, _Context, _Escape) when is_float(Value) ->

--- a/src/walrus.erl
+++ b/src/walrus.erl
@@ -48,7 +48,7 @@ render([{block, Key, SubParseTree} | ParseTree], Context, Acc) ->
         Val when ?is_falsy(Val) ->
             render(ParseTree, Context, Acc);
         Val when is_list(Val) ->
-            Tmpl = [render(SubParseTree, Ctx, []) || Ctx <- Val],
+            Tmpl = [render(SubParseTree, Ctx ++ Context, []) || Ctx <- Val],
             render(ParseTree, Context, [Tmpl | Acc]);
         _ ->
             Tmpl = render(SubParseTree, Context, []),

--- a/src/walrus.erl
+++ b/src/walrus.erl
@@ -5,6 +5,7 @@
 
 -define(is_falsy(V),
     (V =:= false orelse V =:= [] orelse V =:= undefined orelse V =:= null)).
+-define(DEFAULT_VALUE,"").
 
 -type value() :: list() | binary() | integer() | float() | atom().
 -type context() :: [{Key :: string(), Value :: value()}, ...].
@@ -67,7 +68,7 @@ render([], _Context, Acc) ->
 
 -spec get(Key :: atom(), Context :: context()) -> stringifiable().
 get(Key, Context) ->
-    Value = proplists:get_value(Key, Context),
+    Value = proplists:get_value(Key, Context, ?DEFAULT_VALUE),
     if
         is_function(Value) -> Value(Context);
         true -> Value


### PR DESCRIPTION
I was looking for best available mustache templating language implementation in Erlang for one of my projects.
It ended up with choice between Mustache.erl and Walrus, so maybe this small benchmark can help others like me to make some decision.

Obviously it requires both implementations to run, so maybe it's not a good idea to put it inside Walrus repo, up to you.
