### PR TITLE
Add ampersand syntax ({{&content}}) for unescaped content.

### DIFF
--- a/src/walrus_lexer.xrl
+++ b/src/walrus_lexer.xrl
@@ -11,6 +11,7 @@ Rules.
 {{/  : {token,{'{{/',TokenLine}}.
 {{\^ : {token,{'{{^',TokenLine}}.
 {{{  : {token,{'{{{',TokenLine}}.
+{{&  : {token,{'{{&',TokenLine}}.
 \s*{Key}\s*}} : {token,{key,TokenLine,?key(TokenChars,TokenLen)},"}}"}.
 }}   : {token,{'}}',TokenLine}}.
 }}}  : {token,{'}}}',TokenLine}}.

--- a/src/walrus_parser.yrl
+++ b/src/walrus_parser.yrl
@@ -1,6 +1,6 @@
 Nonterminals template token var block inverse.
 
-Terminals text key '{{' '{{{' '{{#' '{{/' '{{^' '}}' '}}}'.
+Terminals text key '{{' '{{{' '{{&' '{{#' '{{/' '{{^' '}}' '}}}'.
 
 Rootsymbol template.
 
@@ -14,6 +14,7 @@ token -> inverse : '$1'.
 
 var -> '{{' key '}}' : {var, ?value('$2')}.
 var -> '{{{' key '}}}' : {var_unescaped, ?value('$2')}.
+var -> '{{&' key '}}' : {var_unescaped, ?value('$2')}.
 
 block -> '{{#' key '}}' template '{{/' key '}}'
     : section(block, '$2', '$6', '$4').


### PR DESCRIPTION
Review please.
